### PR TITLE
Remove deprecated `defaultValue`

### DIFF
--- a/storybook/src/stories/UseTally/stories.tsx
+++ b/storybook/src/stories/UseTally/stories.tsx
@@ -17,9 +17,12 @@ export const socialMedia: StoryObj<Meta<typeof SocialMedia>> = {
     },
   },
   argTypes: {
-    step: { type: 'number', defaultValue: 1 },
+    step: { type: 'number' },
     incrementStep: { type: 'number' },
     decrementStep: { type: 'number' },
+  },
+  args: {
+    step: 1,
   },
   render: args => <SocialMedia {...args} />,
 }


### PR DESCRIPTION
- Closes #18 
- Update social media story to set the initial value in the storybook 7 way