### PR TITLE
Add public access flag to publish workflow

### DIFF
--- a/.github/workflows/publish-too-many-hooks.yml
+++ b/.github/workflows/publish-too-many-hooks.yml
@@ -49,6 +49,7 @@ jobs:
         tag: ${{ inputs.tag }}
         dry-run: ${{ inputs.dry-run }}
         check-version: ${{ inputs.check-version }}
+        access: public
 
     - if: steps.publish.outputs.type != 'none'
       run: |


### PR DESCRIPTION
<!--
Thank you for contributing to `too-many-hooks`! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we will be best able to review your PR.
-->

### Why:

To enable closing #20 

<!-- If there's an existing issue for your change, please replace ISSUE above with a link to the issue (e.g. "Closes #29").
If there's _not_ an existing issue, please replace the above with the rationale for the changes being made. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Add `access: public` to package publish workflow since we are not paying for private repos + it is open source
