### PR TITLE
Add exception to release information validator

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,14 @@ When you're finished with the changes, create a pull request, also known as a PR
 
 > PR titles should be in the imperative mood and summarize the changes the PR makes (e.g. "Update contributing guide").
 
+##### Labels
+
+- PRs that make logical changes must include a semver release label ("patch release", "minor release", "major release")
+- PRs that make changes to documentation must include the "documentation" label
+- PRs that make changes to tooling must include the "tooling" label
+- PRs that restructure code must include the "restructure" label
+- All PRs must include a release label ("patch release", "minor release", "major release") or a label for another kind of change ("documentation", "tooling", "restructure")
+
 #### PR review
 
 Once you submit your PR, one or more of the organizations members will assign the review to themselves and review your changes. We may ask questions or request additional information.
@@ -71,7 +79,7 @@ Once you submit your PR, one or more of the organizations members will assign th
 
 #### Merging PRs
 
-<img src="https://media.giphy.com/media/jpbnoe3UIa8TU8LM13/giphy.gif" width="20" height="20" /> Thank you for contributing! <img src="https://media.giphy.com/media/jpbnoe3UIa8TU8LM13/giphy.gif" width="20" height="20" /> 
+<img src="https://media.giphy.com/media/jpbnoe3UIa8TU8LM13/giphy.gif" width="20" height="20" /> Thank you for contributing! <img src="https://media.giphy.com/media/jpbnoe3UIa8TU8LM13/giphy.gif" width="20" height="20" />
 
 Once your PR is merged, your contributions will be publicly visible in the [Storybook](https://yobgob.github.io/too-many-hooks/) and included in the next release of `too-many-hooks`.
 

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   check-pr:
     name: Validate Release Label and Notes
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release') || !(contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure'))}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -13,10 +13,15 @@ on:
       ]
     paths:
       - "packages/too-many-hooks/**.ts"
+
+env: 
+  IS_LABELED_RELEASE: contains(github.event.pull_request.labels.*.name, 'release')
+  IS_LABELED_NON_LOGICAL: contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure')
+
 jobs:
   check-pr:
     name: Validate Release Label and Notes
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'release') || !(contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure'))}}
+    if: $IS_LABELED_RELEASE || !IS_LABELED_NON_LOGICAL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Why:

Closes #76 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Prevent running the release info validator on PRs that have been labeled as making non-logical changes
  - Only run on PRs with a release label OR without a label for another change
- Add labeling requirements to the contributing guide 
