### PR TITLE
Fix release version info validation workflow

### DIFF
--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -15,29 +15,20 @@ on:
       - "packages/too-many-hooks/**.ts"
 
 env: 
-  IS_LABELED_RELEASE: contains(github.event.pull_request.labels.*.name, 'release')
-  IS_LABELED_NON_LOGICAL: contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure')
+  IS_LABELED_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'patch release') || contains(github.event.pull_request.labels.*.name, 'minor release') || contains(github.event.pull_request.labels.*.name, 'major release') }}
+  IS_LABELED_NON_LOGICAL: ${{ contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure') }}
 
 jobs:
-  get-env-vars:
-    name: Load Environment Vars Into Outputs
-    runs-on: ubuntu-latest
-    outputs: 
-      IS_LABELED_RELEASE: ${{ env.IS_LABELED_RELEASE }}
-      IS_LABELED_NON_LOGICAL: ${{ env.IS_LABELED_NON_LOGICAL }}
-    steps:
-      - run: echo "null"
-      # A step that does something is required for a job to be valid, so this does nothing but allows the job to exist
-
   check-pr:
     name: Validate Release Label and Notes
-    needs: [get-env-vars]
     runs-on: ubuntu-latest
-    if: needs.get-env-vars.IS_LABELED_RELEASE || !needs.get-env-vars.IS_LABELED_NON_LOGICAL
     steps:
-      - uses: actions/checkout@v2
-      - uses: jefflinse/pr-semver-bump@v1
-        name: Validate Pull Request Metadata
+      - name: 'Checkout'
+        if: ${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}
+        uses: actions/checkout@v2
+      - name: 'Validate Pull Request Metadata'
+        if: ${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}
+        uses: jefflinse/pr-semver-bump@v1
         with:
           mode: validate
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -23,11 +23,14 @@ jobs:
     name: Validate Release Label and Notes
     runs-on: ubuntu-latest
     steps:
+      - name: 'Check if needed'
+        id: if
+        run: echo "NEEDS_CHECK=${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}" >> "$GITHUB_OUTPUT"
       - name: 'Checkout'
-        if: ${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}
+        if: ${{ fromJSON(steps.if.outputs.NEEDS_CHECK) }}
         uses: actions/checkout@v2
       - name: 'Validate Pull Request Metadata'
-        if: ${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}
+        if: ${{ fromJSON(steps.if.outputs.NEEDS_CHECK) }}
         uses: jefflinse/pr-semver-bump@v1
         with:
           mode: validate

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -19,10 +19,21 @@ env:
   IS_LABELED_NON_LOGICAL: contains(github.event.pull_request.labels.*.name, 'tooling') || contains(github.event.pull_request.labels.*.name, 'documentation') || contains(github.event.pull_request.labels.*.name, 'restructure')
 
 jobs:
+  get-env-vars:
+    name: Load Environment Vars Into Outputs
+    runs-on: ubuntu-latest
+    outputs: 
+      IS_LABELED_RELEASE: ${{ env.IS_LABELED_RELEASE }}
+      IS_LABELED_NON_LOGICAL: ${{ env.IS_LABELED_NON_LOGICAL }}
+    steps:
+      - run: echo "null"
+      # A step that does something is required for a job to be valid, so this does nothing but allows the job to exist
+
   check-pr:
     name: Validate Release Label and Notes
-    if: $IS_LABELED_RELEASE || !IS_LABELED_NON_LOGICAL
+    needs: [get-env-vars]
     runs-on: ubuntu-latest
+    if: needs.get-env-vars.IS_LABELED_RELEASE || !needs.get-env-vars.IS_LABELED_NON_LOGICAL
     steps:
       - uses: actions/checkout@v2
       - uses: jefflinse/pr-semver-bump@v1


### PR DESCRIPTION
### Why:

Closes #98 

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Add `${{}}` around env variables to evaluate the expressions immediately instead of storing strings
- Move `if` to individual steps to allow accessing env vars without needing an extra job